### PR TITLE
(#2) Make the QR-code center-aligned

### DIFF
--- a/qr.js
+++ b/qr.js
@@ -1045,10 +1045,12 @@
       px /= width;
       px  = Math.floor(px);
 
+      var offset = Math.floor((size - (px * width)) / 2);
+
       // Draw the QR code.
       c2d.clearRect(0, 0, size, size);
       c2d.fillStyle = data.background || '#fff';
-      c2d.fillRect(0, 0, px * (width + 8), px * (width + 8));
+      c2d.fillRect(0, 0, size, size);
       c2d.fillStyle = data.foreground || '#000';
 
       var i, j;
@@ -1056,7 +1058,7 @@
       for (i = 0; i < width; i++) {
         for (j = 0; j < width; j++) {
           if (frame[j * width + i]) {
-            c2d.fillRect(px * i, px * j, px, px);
+            c2d.fillRect(px * i + offset, px * j + offset, px, px);
           }
         }
       }


### PR DESCRIPTION
Without this patch applied the QR-code will be aligned to the top-left of the output image/canvas. If the QR-code is smaller than the image size, there will be whitespace to the bottom-right of the image. This patch fixes this by calculating an offset to make the whitespace equal on all sides of the QR-code.

Fixes #2 