### PR TITLE
Update node-canvas version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "git://github.com/neocotic/qr.js.git"
   },
   "dependencies": {
-    "canvas": "~1.1.6"
+    "canvas": "~1.2.9"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
Update node-canvas version to `1.2.9` to get the compatibility with NodeJS 4.0.0